### PR TITLE
`s/Questions/Challenges`

### DIFF
--- a/ppcg.user.js
+++ b/ppcg.user.js
@@ -382,7 +382,7 @@ if (site === 'main' || site === 'meta') {
   showProposeChallengeButton();
 
   if (site == 'main') {
-    $('nav-questions').innerHTML = 'Challenges';
+    document.getElementById('nav-questions').textContent = 'Challenges';
     showLeaderboard();
     // either editing or asking a question
     if (/questions\/ask/.test(document.location.href)) {

--- a/ppcg.user.js
+++ b/ppcg.user.js
@@ -382,6 +382,7 @@ if (site === 'main' || site === 'meta') {
   showProposeChallengeButton();
 
   if (site == 'main') {
+    $('nav-questions').innerHTML = 'Challenges';
     showLeaderboard();
     // either editing or asking a question
     if (/questions\/ask/.test(document.location.href)) {


### PR DESCRIPTION
The title says it all. We have "Post Challenge" and "Porpoise Challenge", so why not have "Challenges" instead of "Questions" in the nav bar?