### PR TITLE
Change update link

### DIFF
--- a/ppcg.user.js
+++ b/ppcg.user.js
@@ -12,7 +12,7 @@
 // @grant       GM_listValues
 // @grant       GM_deleteValue
 // @require     https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js
-// @updateURL   https://rawgit.com/vihanb/PPCG-Design/master/ppcg.user.js
+// @updateURL   https://github.com/vihanb/PPCG-Design/raw/master/ppcg.user.js
 // ==/UserScript==
 ////////////////////////////////////////////////////////////////////////
 //////////////////////                        //////////////////////////


### PR DESCRIPTION
According to [RawGit](https://rawgit.com) website, it won't be available since October 2019. Even though there is still time, it's better to move sooner than later. Both Tampermonkey and Greasemonkey support scripts from GitHub's "raw" links.